### PR TITLE
Clean input code of comments before sending to psysh to execute 

### DIFF
--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -71,7 +71,7 @@ class Tinker
 
     public function removeComments(string $code): string
     {
-        $tokens = token_get_all("<?php\n".$code."?>");
+        $tokens = token_get_all("<?php\n".$code.'?>');
         $cleanCode = '';
         foreach ($tokens as $token) {
             if (is_string($token)) {

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -69,7 +69,7 @@ class Tinker
         return $shell;
     }
 
-    public function removeComments($code)
+    public function removeComments(string: $code): string
     {
         $tokens = token_get_all("<?php\n".$code."\n?>");
         $cleanCode = "";

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -71,12 +71,13 @@ class Tinker
 
     public function removeComments(string $code): string
     {
-        $tokens = token_get_all("<?php\n".$code."\n?>");
-        $cleanCode = "";
+        $tokens = token_get_all("<?php\n".$code."?>");
+        $cleanCode = '';
         foreach ($tokens as $token) {
             if (is_string($token)) {
                 // simple 1-character token
                 $cleanCode .= $token;
+
             } else {
                 // token array
                 list($id, $text) = $token;

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -71,32 +71,27 @@ class Tinker
 
     public function removeComments(string $code): string
     {
-        $tokens = token_get_all("<?php\n".$code.'?>');
-        $cleanCode = '';
-        foreach ($tokens as $token) {
-            if (is_string($token)) {
-                // simple 1-character token
-                $cleanCode .= $token;
-            } else {
-                // token array
-                list($id, $text) = $token;
+        $tokens = collect(token_get_all("<?php\n".$code.'?>'));
 
-                switch ($id) {
-                    case T_COMMENT:
-                    case T_DOC_COMMENT:
-                    case T_OPEN_TAG:
-                    case T_CLOSE_TAG:
-                        // no action on comments and php tags
-                        break;
-                    default:
-                        // anything else -> output "as is"
-                        $cleanCode .= $text;
-                        break;
-                }
-            }
-        }
+        return $tokens->reduce(function($carry, $token) {
+                if(is_string($token))
+                    return $carry.$token;
 
-        return $cleanCode;
+                // Destructure token array
+                [$id, $text] = $token;
+
+                // Ingore comments and php tags
+                if($id === T_COMMENT)
+                    return $carry;
+                if($id === T_DOC_COMMENT)
+                    return $carry;
+                if($id === T_OPEN_TAG)
+                    return $carry;
+                if($id === T_CLOSE_TAG)
+                    return $carry;
+
+                return $carry.$text;
+            }, "");
     }
 
     protected function cleanOutput(string $output): string

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -69,7 +69,7 @@ class Tinker
         return $shell;
     }
 
-    public function removeComments(string: $code): string
+    public function removeComments(string $code): string
     {
         $tokens = token_get_all("<?php\n".$code."\n?>");
         $cleanCode = "";

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -74,23 +74,28 @@ class Tinker
         $tokens = collect(token_get_all("<?php\n".$code.'?>'));
 
         return $tokens->reduce(function($carry, $token) {
-            if(is_string($token))
-                return $carry.$token;
+            if(is_string($token)) {
+                return $carry . $token;
+            }
 
             // Destructure token array
             [$id, $text] = $token;
 
             // Ingore comments and php tags
-            if($id === T_COMMENT)
+            if($id === T_COMMENT) {
                 return $carry;
-            if($id === T_DOC_COMMENT)
+            }
+            if($id === T_DOC_COMMENT) {
                 return $carry;
-            if($id === T_OPEN_TAG)
+            }
+            if($id === T_OPEN_TAG) {
                 return $carry;
-            if($id === T_CLOSE_TAG)
+            }
+            if($id === T_CLOSE_TAG) {
                 return $carry;
+            }
 
-            return $carry.$text;
+            return $carry . $text;
         }, "");
     }
 

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -95,6 +95,7 @@ class Tinker
                 }
             }
         }
+
         return $cleanCode;
     }
 

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -73,8 +73,8 @@ class Tinker
     {
         $tokens = collect(token_get_all("<?php\n".$code.'?>'));
 
-        return $tokens->reduce(function($carry, $token) {
-            if(is_string($token)) {
+        return $tokens->reduce(function ($carry, $token) {
+            if (is_string($token)) {
                 return $carry . $token;
             }
 
@@ -82,21 +82,21 @@ class Tinker
             [$id, $text] = $token;
 
             // Ingore comments and php tags
-            if($id === T_COMMENT) {
+            if ($id === T_COMMENT) {
                 return $carry;
             }
-            if($id === T_DOC_COMMENT) {
+            if ($id === T_DOC_COMMENT) {
                 return $carry;
             }
-            if($id === T_OPEN_TAG) {
+            if ($id === T_OPEN_TAG) {
                 return $carry;
             }
-            if($id === T_CLOSE_TAG) {
+            if ($id === T_CLOSE_TAG) {
                 return $carry;
             }
 
             return $carry . $text;
-        }, "");
+        }, '');
     }
 
     protected function cleanOutput(string $output): string

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -78,25 +78,30 @@ class Tinker
                 return $carry.$token;
             }
 
-            // Destructure token array
-            [$id, $text] = $token;
-
-            // Ingore comments and php tags
-            if ($id === T_COMMENT) {
-                return $carry;
-            }
-            if ($id === T_DOC_COMMENT) {
-                return $carry;
-            }
-            if ($id === T_OPEN_TAG) {
-                return $carry;
-            }
-            if ($id === T_CLOSE_TAG) {
-                return $carry;
-            }
+            $text = $this->ignoreCommentsAndPhpTags($token);
 
             return $carry.$text;
         }, '');
+    }
+
+    protected function ignoreCommentsAndPhpTags(array $token)
+    {
+        [$id, $text] = $token;
+
+        if ($id === T_COMMENT) {
+            return '';
+        }
+        if ($id === T_DOC_COMMENT) {
+            return '';
+        }
+        if ($id === T_OPEN_TAG) {
+            return '';
+        }
+        if ($id === T_CLOSE_TAG) {
+            return '';
+        }
+
+        return $text;
     }
 
     protected function cleanOutput(string $output): string

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -77,7 +77,6 @@ class Tinker
             if (is_string($token)) {
                 // simple 1-character token
                 $cleanCode .= $token;
-
             } else {
                 // token array
                 list($id, $text) = $token;

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -75,7 +75,7 @@ class Tinker
 
         return $tokens->reduce(function ($carry, $token) {
             if (is_string($token)) {
-                return $carry . $token;
+                return $carry.$token;
             }
 
             // Destructure token array
@@ -95,7 +95,7 @@ class Tinker
                 return $carry;
             }
 
-            return $carry . $text;
+            return $carry.$text;
         }, '');
     }
 

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -74,24 +74,24 @@ class Tinker
         $tokens = collect(token_get_all("<?php\n".$code.'?>'));
 
         return $tokens->reduce(function($carry, $token) {
-                if(is_string($token))
-                    return $carry.$token;
+            if(is_string($token))
+                return $carry.$token;
 
-                // Destructure token array
-                [$id, $text] = $token;
+            // Destructure token array
+            [$id, $text] = $token;
 
-                // Ingore comments and php tags
-                if($id === T_COMMENT)
-                    return $carry;
-                if($id === T_DOC_COMMENT)
-                    return $carry;
-                if($id === T_OPEN_TAG)
-                    return $carry;
-                if($id === T_CLOSE_TAG)
-                    return $carry;
+            // Ingore comments and php tags
+            if($id === T_COMMENT)
+                return $carry;
+            if($id === T_DOC_COMMENT)
+                return $carry;
+            if($id === T_OPEN_TAG)
+                return $carry;
+            if($id === T_CLOSE_TAG)
+                return $carry;
 
-                return $carry.$text;
-            }, "");
+            return $carry.$text;
+        }, "");
     }
 
     protected function cleanOutput(string $output): string

--- a/tests/TinkerTest.php
+++ b/tests/TinkerTest.php
@@ -6,6 +6,7 @@ use Spatie\WebTinker\Tinker;
 
 class TinkerTest extends TestCase
 {
+    /** @var \Spatie\WebTinker\Tinker */
     private $tinker;
 
     public function setUp(): void

--- a/tests/TinkerTest.php
+++ b/tests/TinkerTest.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\WebTinker\Tests;
 
-
 use Spatie\WebTinker\Tinker;
 
 class TinkerTest extends TestCase

--- a/tests/TinkerTest.php
+++ b/tests/TinkerTest.php
@@ -8,7 +8,7 @@ use Spatie\WebTinker\Tinker;
 class TinkerTest extends TestCase
 {
     /** @test */
-    function remove_c_style_single_line_comments()
+    public function remove_c_style_single_line_comments()
     {
         $tinker = new Tinker();
 

--- a/tests/TinkerTest.php
+++ b/tests/TinkerTest.php
@@ -13,6 +13,7 @@ class TinkerTest extends TestCase
         parent::setUp();
         $this->tinker = new Tinker();
     }
+
     /** @test */
     public function it_removes_c_style_single_line_comments()
     {

--- a/tests/TinkerTest.php
+++ b/tests/TinkerTest.php
@@ -22,7 +22,7 @@ class TinkerTest extends TestCase
     }
 
     /** @test */
-    function remove_shell_style_single_line_comments()
+    public function remove_shell_style_single_line_comments()
     {
         $tinker = new Tinker();
 
@@ -36,7 +36,7 @@ class TinkerTest extends TestCase
     }
 
     /** @test */
-    function remove_php_multi_line_comments()
+    public function remove_php_multi_line_comments()
     {
         $tinker = new Tinker();
 
@@ -47,7 +47,7 @@ class TinkerTest extends TestCase
         // Multi line comment at the end of a line of code
         $cleanCode = $tinker->removeComments(
             "\$user = 'Test User';/* This is a multi line comment \n".
-            " yet another line of comment */"
+            ' yet another line of comment */'
         );
         $this->assertSame('$user = \'Test User\';', $cleanCode);
 
@@ -60,14 +60,14 @@ class TinkerTest extends TestCase
     }
 
     /** @test */
-    function remove_comments_with_multiline_code_input()
+    public function remove_comments_with_multiline_code_input()
     {
         $tinker = new Tinker();
 
         // Multi line comment in between lines of code
         $cleanCode = $tinker->removeComments(
             "\$user_id = 1; /* This is a multi line comment \n yet another line of comment */\n".
-            "\\App\\User::find(\$user_id);"
+            '\App\User::find($user_id);'
         );
         $this->assertSame("\$user_id = 1; \n\\App\\User::find(\$user_id);", $cleanCode);
 

--- a/tests/TinkerTest.php
+++ b/tests/TinkerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Spatie\WebTinker\Tests;
+
+
+use Spatie\WebTinker\Tinker;
+
+class TinkerTest extends TestCase
+{
+    /** @test */
+    function remove_c_style_single_line_comments()
+    {
+        $tinker = new Tinker();
+
+        // Only comment
+        $cleanCode = $tinker->removeComments('// This is a comment ');
+        $this->assertSame('', $cleanCode);
+
+        // Comment at the end of line of code
+        $cleanCode = $tinker->removeComments('$user = \'Test\'; // This is a comment ');
+        $this->assertSame('$user = \'Test\'; ', $cleanCode);
+    }
+
+    /** @test */
+    function remove_shell_style_single_line_comments()
+    {
+        $tinker = new Tinker();
+
+        // Only comment
+        $cleanCode = $tinker->removeComments('# This is a comment ');
+        $this->assertSame('', $cleanCode);
+
+        // Comment at the end of line of code
+        $cleanCode = $tinker->removeComments('$user = \'Test\'; # This is a comment ');
+        $this->assertSame('$user = \'Test\'; ', $cleanCode);
+    }
+
+    /** @test */
+    function remove_php_multi_line_comments()
+    {
+        $tinker = new Tinker();
+
+        // Only comment
+        $cleanCode = $tinker->removeComments("/* This is a multi line comment \n yet another line of comment */");
+        $this->assertSame('', $cleanCode);
+
+        // Multi line comment at the end of a line of code
+        $cleanCode = $tinker->removeComments(
+            "\$user = 'Test User';/* This is a multi line comment \n".
+            " yet another line of comment */"
+        );
+        $this->assertSame('$user = \'Test User\';', $cleanCode);
+
+        // Inline Multi line comment
+        $cleanCode = $tinker->removeComments(
+            "\$user = /* This is a multi line comment \n".
+            " yet another line of comment */'Test User';"
+        );
+        $this->assertSame('$user = \'Test User\';', $cleanCode);
+    }
+
+    /** @test */
+    function remove_comments_with_multiline_code_input()
+    {
+        $tinker = new Tinker();
+
+        // Multi line comment in between lines of code
+        $cleanCode = $tinker->removeComments(
+            "\$user_id = 1; /* This is a multi line comment \n yet another line of comment */\n".
+            "\\App\\User::find(\$user_id);"
+        );
+        $this->assertSame("\$user_id = 1; \n\\App\\User::find(\$user_id);", $cleanCode);
+
+        // C Style commented line of code
+        $cleanCode = $tinker->removeComments(
+            "\$newUsers = User::latest()->take(3)->get();\n\n// \$allUsers = User::all();"
+        );
+        $this->assertSame("\$newUsers = User::latest()->take(3)->get();\n\n", $cleanCode);
+
+        // Shell Style commented line of code
+        $cleanCode = $tinker->removeComments(
+            "\$newUsers = User::latest()->take(3)->get();\n\n# \$allUsers = User::all();"
+        );
+        $this->assertSame("\$newUsers = User::latest()->take(3)->get();\n\n", $cleanCode);
+    }
+}

--- a/tests/TinkerTest.php
+++ b/tests/TinkerTest.php
@@ -6,52 +6,46 @@ use Spatie\WebTinker\Tinker;
 
 class TinkerTest extends TestCase
 {
-    /** @test */
-    public function remove_c_style_single_line_comments()
-    {
-        $tinker = new Tinker();
+    private $tinker;
 
-        // Only comment
-        $cleanCode = $tinker->removeComments('// This is a comment ');
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->tinker = new Tinker();
+    }
+    /** @test */
+    public function it_removes_c_style_single_line_comments()
+    {
+        $cleanCode = $this->tinker->removeComments('// This is a comment ');
         $this->assertSame('', $cleanCode);
 
-        // Comment at the end of line of code
-        $cleanCode = $tinker->removeComments('$user = \'Test\'; // This is a comment ');
+        $cleanCode = $this->tinker->removeComments('$user = \'Test\'; // This is a comment ');
         $this->assertSame('$user = \'Test\'; ', $cleanCode);
     }
 
     /** @test */
-    public function remove_shell_style_single_line_comments()
+    public function it_removes_shell_style_single_line_comments()
     {
-        $tinker = new Tinker();
-
-        // Only comment
-        $cleanCode = $tinker->removeComments('# This is a comment ');
+        $cleanCode = $this->tinker->removeComments('# This is a comment ');
         $this->assertSame('', $cleanCode);
 
-        // Comment at the end of line of code
-        $cleanCode = $tinker->removeComments('$user = \'Test\'; # This is a comment ');
+        $cleanCode = $this->tinker->removeComments('$user = \'Test\'; # This is a comment ');
         $this->assertSame('$user = \'Test\'; ', $cleanCode);
     }
 
     /** @test */
-    public function remove_php_multi_line_comments()
+    public function it_removes_php_multi_line_comments()
     {
-        $tinker = new Tinker();
-
-        // Only comment
-        $cleanCode = $tinker->removeComments("/* This is a multi line comment \n yet another line of comment */");
+        $cleanCode = $this->tinker->removeComments("/* This is a multi line comment \n yet another line of comment */");
         $this->assertSame('', $cleanCode);
 
-        // Multi line comment at the end of a line of code
-        $cleanCode = $tinker->removeComments(
+        $cleanCode = $this->tinker->removeComments(
             "\$user = 'Test User';/* This is a multi line comment \n".
             ' yet another line of comment */'
         );
         $this->assertSame('$user = \'Test User\';', $cleanCode);
 
-        // Inline Multi line comment
-        $cleanCode = $tinker->removeComments(
+        $cleanCode = $this->tinker->removeComments(
             "\$user = /* This is a multi line comment \n".
             " yet another line of comment */'Test User';"
         );
@@ -59,25 +53,20 @@ class TinkerTest extends TestCase
     }
 
     /** @test */
-    public function remove_comments_with_multiline_code_input()
+    public function it_removes_comments_with_multiline_code_input()
     {
-        $tinker = new Tinker();
-
-        // Multi line comment in between lines of code
-        $cleanCode = $tinker->removeComments(
+        $cleanCode = $this->tinker->removeComments(
             "\$user_id = 1; /* This is a multi line comment \n yet another line of comment */\n".
             '\App\User::find($user_id);'
         );
         $this->assertSame("\$user_id = 1; \n\\App\\User::find(\$user_id);", $cleanCode);
 
-        // C Style commented line of code
-        $cleanCode = $tinker->removeComments(
+        $cleanCode = $this->tinker->removeComments(
             "\$newUsers = User::latest()->take(3)->get();\n\n// \$allUsers = User::all();"
         );
         $this->assertSame("\$newUsers = User::latest()->take(3)->get();\n\n", $cleanCode);
 
-        // Shell Style commented line of code
-        $cleanCode = $tinker->removeComments(
+        $cleanCode = $this->tinker->removeComments(
             "\$newUsers = User::latest()->take(3)->get();\n\n# \$allUsers = User::all();"
         );
         $this->assertSame("\$newUsers = User::latest()->take(3)->get();\n\n", $cleanCode);


### PR DESCRIPTION
This pull request cleans the input code of comments before sending to psysh to execute #8 