### PR TITLE
fix: Prevent dark and auto themes to be purged from app.css

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -5,7 +5,7 @@ mix
     .setPublicPath('public')
     .postCss('resources/css/app.css', 'public')
     .purgeCss({
-        whitelistPatterns: [/CodeMirror/, /cm/],
+        whitelistPatterns: [/CodeMirror/, /cm/, /^theme-/],
     })
     .js('resources/js/app.js', 'public')
     .version()


### PR DESCRIPTION
Hi,
This pull request prevents dark and auto themes classes (theme-dark and theme-auto) to be purged from app.css by purgeCss.
The issue appeared with this commit https://github.com/spatie/laravel-web-tinker/commit/906385e18c54cf92a2ebf7441adf238fa53cea87.
As app.css is a compiled file, I let you rebuild app.css in Antwerp :)

Thank you