### PR TITLE
support for custom PsySH  config 

### DIFF
--- a/config/web-tinker.php
+++ b/config/web-tinker.php
@@ -17,4 +17,11 @@ return [
      * Do not change this, unless you know what your are doing.
      */
     'enabled' => env('APP_ENV') === 'local',
+
+    /*
+     * If you want to fine-tune PsySH configuration specify
+     * configuration file name, relative to the root of your 
+     * application directory.
+     */
+    'config_file' => env('PSYSH_CONFIG', null),
 ];

--- a/config/web-tinker.php
+++ b/config/web-tinker.php
@@ -20,7 +20,7 @@ return [
 
     /*
      * If you want to fine-tune PsySH configuration specify
-     * configuration file name, relative to the root of your 
+     * configuration file name, relative to the root of your
      * application directory.
      */
     'config_file' => env('PSYSH_CONFIG', null),

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -48,7 +48,7 @@ class Tinker
     {
         $config = new Configuration([
             'updateCheck' => 'never',
-            'configFile' => config('web-tinker.config_file') !== null ? base_path().'/'.config('web-tinker.config_file') : null
+            'configFile' => config('web-tinker.config_file') !== null ? base_path().'/'.config('web-tinker.config_file') : null,
         ]);
 
         $config->getPresenter()->addCasters([

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -48,6 +48,7 @@ class Tinker
     {
         $config = new Configuration([
             'updateCheck' => 'never',
+            'configFile' => config('web-tinker.config_file') !== null ? base_path().'/'.config('web-tinker.config_file') : null
         ]);
 
         $config->getPresenter()->addCasters([


### PR DESCRIPTION
Hi there, 

saw a post about this issue (#17) on Twitter 

As per PsySH documentation, the custom config file path can be provided in the project .env file but for some reason, it doesn't load.

In this PR I added support for loading config file providing a path in the project .env file.

`PSYSH_CONFIG=.psysh.php`


 