### PR TITLE
Option for timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ return [
      * application directory.
      */
     'config_file' => env('PSYSH_CONFIG', null),
+
+    /*
+     * Show execution timestamp
+     */
+    'show_timestamp' => false,
 ];
 ```
 

--- a/config/web-tinker.php
+++ b/config/web-tinker.php
@@ -24,4 +24,9 @@ return [
      * application directory.
      */
     'config_file' => env('PSYSH_CONFIG', null),
+
+    /*
+     * Show execution timestamp
+     */
+    'show_timestamp' => false,
 ];

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -109,6 +109,15 @@ class Tinker
     {
         $output = preg_replace('/(?s)(<aside.*?<\/aside>)|Exit:  Ctrl\+D/ms', '$2', $output);
 
+        if (config('web-tinker.show_timestamp')) {
+        	$output = $this->getTimestamp().$output;
+        }
+
         return trim($output);
+    }
+
+    protected function getTimestamp()
+    {
+    	return '<span class="text-dimmed">'.now().'</span><br>';
     }
 }

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -110,7 +110,7 @@ class Tinker
         $output = preg_replace('/(?s)(<aside.*?<\/aside>)|Exit:  Ctrl\+D/ms', '$2', $output);
 
         if (config('web-tinker.show_timestamp')) {
-        	$output = $this->getTimestamp().$output;
+            $output = $this->getTimestamp().$output;
         }
 
         return trim($output);
@@ -118,6 +118,6 @@ class Tinker
 
     protected function getTimestamp()
     {
-    	return '<span class="text-dimmed">'.now().'</span><br>';
+        return '<span class="text-dimmed">'.now().'</span><br>';
     }
 }


### PR DESCRIPTION
As requested here #12, sometimes it is useful to see the timestamp of execution. In this PR I added support for optionally enabling timestamp in the results panel.

![](https://i.imgur.com/kJIR5dO.png)