### PR TITLE
Fix "Writing to /var/www/.config/psysh is not allowed"

### DIFF
--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -54,6 +54,8 @@ class Tinker
             'configFile' => config('web-tinker.config_file') !== null ? base_path().'/'.config('web-tinker.config_file') : null,
         ]);
 
+        $config->setHistoryFile(defined('PHP_WINDOWS_VERSION_BUILD') ? 'nul' : '/dev/null');
+
         $config->getPresenter()->addCasters([
             Collection::class => 'Laravel\Tinker\TinkerCaster::castCollection',
             Model::class => 'Laravel\Tinker\TinkerCaster::castModel',


### PR DESCRIPTION
I got this error whenever I tried to run a command, because I have PHP running under the `www-data` user, which has it's HOME set to `/var/www`, which is not writable.

> ErrorException (E_USER_NOTICE)
> Writing to /var/www/.config/psysh is not allowed.
> …/vendor/psy/psysh/src/ConfigPaths.php:228

This fixes it by disabling the history file. Since the history file isn't used in the web shell I think it's probably the best solution.

(Not tested on Windows, but I think it will work.)