### PR TITLE
use a custorm Shell to avoid \readline

### DIFF
--- a/src/Shell/Shell.php
+++ b/src/Shell/Shell.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\WebTinker\Shell;
+
+use Psy\Shell as PsyShell;
+
+class Shell extends PsyShell
+{
+    protected function readline()
+    {
+        if (!empty($this->inputBuffer)) {
+            $line = \array_shift($this->inputBuffer);
+            if (!$line instanceof SilentInput) {
+                $this->output->writeln(\sprintf('<aside>%s %s</aside>', static::REPLAY, OutputFormatter::escape($line)));
+            }
+
+            return $line;
+        }
+
+        return false;
+    }
+}

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\WebTinker;
 
-use Psy\Shell;
 use Psy\Configuration;
 use Psy\ExecutionLoopClosure;
 use Illuminate\Support\Collection;
@@ -10,6 +9,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Database\Eloquent\Model;
 use Laravel\Tinker\ClassAliasAutoloader;
 use Spatie\WebTinker\OutputModifiers\OutputModifier;
+use Spatie\WebTinker\Shell\Shell;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 class Tinker
@@ -17,7 +17,7 @@ class Tinker
     /** @var \Symfony\Component\Console\Output\BufferedOutput */
     protected $output;
 
-    /** @var \Psy\Shell */
+    /** @var Shell */
     protected $shell;
 
     /** @var \Spatie\WebTinker\OutputModifiers\OutputModifier */


### PR DESCRIPTION
With pysh official Shell, laravel-web-tinker can not work together with [LaravelFly](laravel-web-tinker). Because after coping with user input from web, Shell will use `\readline()` which always waits for user input from cli.  LaravelFly is a php cli app.

The new Shell only uses user input from web, not considering `\readline()` any more.

