### PR TITLE
Add web middleware to route

### DIFF
--- a/src/WebTinkerServiceProvider.php
+++ b/src/WebTinkerServiceProvider.php
@@ -46,7 +46,7 @@ class WebTinkerServiceProvider extends ServiceProvider
 
     protected function registerRoutes()
     {
-        Route::prefix(config('web-tinker.path'))->middleware(Authorize::class)->group(function () {
+        Route::prefix(config('web-tinker.path'))->middleware(['web', Authorize::class])->group(function () {
             Route::get('/', [WebTinkerController::class, 'index']);
             Route::post('/', [WebTinkerController::class, 'execute']);
         });


### PR DESCRIPTION
This would resolve https://github.com/spatie/laravel-web-tinker/issues/32 if it's the desired way forward. It feels wrong that you'd have to include the web middleware for the user to be available to the gate closure but that seems to be the behavior. 