### PR TITLE
Can't execute code when running Laravel from subfolder

### DIFF
--- a/src/Http/Controllers/WebTinkerController.php
+++ b/src/Http/Controllers/WebTinkerController.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\WebTinker\Http\Controllers;
 
+use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Http\Request;
 use Spatie\WebTinker\Tinker;
 
@@ -9,7 +10,9 @@ class WebTinkerController
 {
     public function index()
     {
-        return view('web-tinker::web-tinker', ['path' => config('web-tinker.path')]);
+        return view('web-tinker::web-tinker', [
+            'path' => app(UrlGenerator::class)->to(config('web-tinker.path')),
+        ]);
     }
 
     public function execute(Request $request, Tinker $tinker)


### PR DESCRIPTION
When Laravel is setup outside of the web server document root, the code cannot be executed as the Laravel installation relative path is omitted.
The Web tinker on URL `http://localhost/my/sub/folder/public/tinker` tries to execute code on `http://localhost/tinker.`

This adds a dependency to Laravel Routing module. Do you want me to add it to the composer.json file?