### PR TITLE
Clean '<whisper> - </whisper>' and 'INFO Ctrl+D' from the output

### DIFF
--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -114,6 +114,8 @@ class Tinker
     {
         $output = preg_replace('/(?s)(<aside.*?<\/aside>)|Exit:  Ctrl\+D/ms', '$2', $output);
 
+        $output = preg_replace('/(?s)(<whisper.*?<\/whisper>)|INFO  Ctrl\+D\./ms', '$2', $output);
+
         return trim($output);
     }
 }


### PR DESCRIPTION
Removed `<whisper> - </whisper>` and `INFO Ctrl+D` from the output when updating to Laravel 10.