### PR TITLE
Prevent HTML injection

### DIFF
--- a/src/OutputModifiers/PrefixDateTime.php
+++ b/src/OutputModifiers/PrefixDateTime.php
@@ -6,6 +6,8 @@ class PrefixDateTime implements OutputModifier
 {
     public function modify(string $output = ''): string
     {
+        $output = htmlentities($output);
+
         return '<span class="text-dimmed">'.now()->format('Y-m-d H:i:s').'</span><br>'.$output;
     }
 }

--- a/src/OutputModifiers/PrefixDateTime.php
+++ b/src/OutputModifiers/PrefixDateTime.php
@@ -6,8 +6,6 @@ class PrefixDateTime implements OutputModifier
 {
     public function modify(string $output = ''): string
     {
-        $output = htmlentities($output);
-
         return '<span class="text-dimmed">'.now()->format('Y-m-d H:i:s').'</span><br>'.$output;
     }
 }

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -35,7 +35,7 @@ class Tinker
     public function execute(string $phpCode): string
     {
         $phpCode = $this->removeComments($phpCode);
-        
+
         $this->shell->addInput($phpCode);
 
         $closure = new ExecutionLoopClosure($this->shell);
@@ -116,6 +116,6 @@ class Tinker
 
         $output = preg_replace('/(?s)(<whisper.*?<\/whisper>)|INFO  Ctrl\+D\./ms', '$2', $output);
 
-        return trim($output);
+        return htmlentities(trim($output));
     }
 }


### PR DESCRIPTION
Unfortunately these changes also mean that things like `var_dump(...)` and `dd(...)` will not render on the page but instead will show up as plain text. I'm not sure if there is a way to get Web Tinker to behave the same way as the Tinker shell would inside of a terminal, meaning it'd use a different strategy for things like `var_dump(...)` and `dd(...)`.

Closes #106.