### PR TITLE
Add CSS styles for preformatted text

### DIFF
--- a/resources/js/components/TinkerOutput.vue
+++ b/resources/js/components/TinkerOutput.vue
@@ -9,3 +9,10 @@ export default {
     props: ['value'],
 };
 </script>
+
+<style>
+pre {
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+</style>


### PR DESCRIPTION
Add styles for preformatted text in TinkerOutput.vue

so we dont have to horizontally scroll the output + make it easier to read